### PR TITLE
Talisman support

### DIFF
--- a/src/main/java/com/easyEmpty/EasyEmptyConfig.java
+++ b/src/main/java/com/easyEmpty/EasyEmptyConfig.java
@@ -54,4 +54,10 @@ public interface EasyEmptyConfig extends Config
     {
         return true;
     }
+    @ConfigItem(keyName = "swapTali", name = "Talisman swaps", description = "withdraw-2/3 from bank menu", position = 5)
+    default boolean swapTali()
+    {
+        return true;
+    }
+    
 }

--- a/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
+++ b/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
@@ -94,8 +94,8 @@ public class EasyEmptyPlugin extends Plugin
 		bankFill = config.bankFill();
 		swapStam = config.swapStam();
 		swapNeck = config.swapNeck();
-		emptyPouches = config.emptyPouches();
 		swapTali = config.swapTali();
+		emptyPouches = config.emptyPouches();
 		log.info("Easy Empty  started!");
 	}
 

--- a/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
+++ b/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
@@ -122,6 +122,10 @@ public class EasyEmptyPlugin extends Plugin
 				if (widget != null && (entryType == MenuAction.CC_OP_LOW_PRIORITY || entryType == MenuAction.CC_OP) &&
 					((bankFill && entryOption.startsWith("Fill") && ArrayUtils.contains(pouches, widget.getItemId())) ||
 					(swapStam && entryOption.matches("Drink|Withdraw-1") && widget.getItemId() == ItemID.STAMINA_POTION1) ||
+					(swapTali && entryOption.matches("Withdraw-2") && widget.getItemId() == ItemID.EARTH_TALISMAN) ||
+					(swapTali && entryOption.matches("Withdraw-3") && widget.getItemId() == ItemID.EARTH_TALISMAN) ||
+					(swapTali && entryOption.matches("Withdraw-2") && widget.getItemId() == ItemID.WATER_TALISMAN) ||
+					(swapTali && entryOption.matches("Withdraw-3") && widget.getItemId() == ItemID.WATER_TALISMAN) ||
 					(swapNeck && entryOption.matches("Wear|Withdraw-1") && widget.getItemId() == ItemID.BINDING_NECKLACE))) {
 					MenuEntry entry = menuEntries[i];
 
@@ -188,7 +192,9 @@ public class EasyEmptyPlugin extends Plugin
 									break;
 				case "swapStam":	swapStam = config.swapStam();
 									break;
-				case "emptyPouches":emptyPouches = config.emptyPouches();
+				case "emptyPouches":	emptyPouches = config.emptyPouches();
+									break;
+				case "swapTali":	emptyPouches = config.swapTali();
 									break;
 			}
 		}

--- a/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
+++ b/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
@@ -80,7 +80,7 @@ public class EasyEmptyPlugin extends Plugin
 
 	private static final WorldArea zmi = new WorldArea(new WorldPoint(3050, 5573, 0), 20, 20);
 
-	boolean bankFill, swapStam, swapNeck, emptyPouches;
+	boolean bankFill, swapStam, swapNeck, emptyPouches, swapTali;
 
 	@Inject
 	private Client client;
@@ -95,6 +95,7 @@ public class EasyEmptyPlugin extends Plugin
 		swapStam = config.swapStam();
 		swapNeck = config.swapNeck();
 		emptyPouches = config.emptyPouches();
+		swapTali = config.swapTali();
 		log.info("Easy Empty  started!");
 	}
 


### PR DESCRIPTION
For niche account build's ie skillers or pures they need talismans instead of magic imbue. 

These changes make the earth/water talisman be withdraw 2 or 3 depending on which withdraw x you have set.

This functionality is in the essence running plugin, but only uses withdraw 2 on the earth talismans, along with there project not been updated in years. As your is active I hope we can have this functionally in yours along with the other useful options so essence running plugin is not needed.