### PR TITLE
Add Shrine of Ralos chunks to altar array

### DIFF
--- a/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
+++ b/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
@@ -63,7 +63,12 @@ public class EasyEmptyPlugin extends Plugin
 		8779,  // Death
 		9291, // Wrath
 		8508, // Astral
-		12875 // Blood
+		12875, // Blood
+		5681, // The Teomat
+		6703, // Outer Fortis
+		6704, // Civitas Illa Fortis
+		6193, // Ortus Farm
+		6957 // Stonecutter Outpost
 	};
 
 	int[] pouches = {


### PR DESCRIPTION
The Shrines of Ralos were added in the update Varlamore: Part One.

Added the chunk IDs that the 5 shrines exist within. No entities are contained within the chunks that would expect a player to be filling a rune pouch.