### PR TITLE
Adding option to hide deposit when pouches are full

### DIFF
--- a/src/main/java/com/easyEmpty/EasyEmptyConfig.java
+++ b/src/main/java/com/easyEmpty/EasyEmptyConfig.java
@@ -43,13 +43,19 @@ public interface EasyEmptyConfig extends Config
         return true;
     }
 
-    @ConfigItem(keyName = "swapStam", name = "Stamina Potion(1) swaps", description = "Left-click drink/withdraw-1 from bank menu", position = 3)
+    @ConfigItem(keyName = "hideDeposit", name = "Hide deposit once pouches are full", description = "Replaces the deposit option with 'Empty' when pouches are full", position = 3)
+    default boolean bankFill()
+    {
+        return true;
+    }
+
+    @ConfigItem(keyName = "swapStam", name = "Stamina Potion(1) swaps", description = "Left-click drink/withdraw-1 from bank menu", position = 4)
     default boolean swapStam()
     {
         return true;
     }
 
-    @ConfigItem(keyName = "swapNeck", name = "Binding Necklace swaps", description = "Left-click wear/withdraw-1 from bank menu", position = 4)
+    @ConfigItem(keyName = "swapNeck", name = "Binding Necklace swaps", description = "Left-click wear/withdraw-1 from bank menu", position = 5)
     default boolean swapNeck()
     {
         return true;

--- a/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
+++ b/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
@@ -122,7 +122,7 @@ public class EasyEmptyPlugin extends Plugin
 
 				
 				if (widget != null && (entryType == MenuAction.CC_OP_LOW_PRIORITY || entryType == MenuAction.CC_OP) &&
-					((hideDeposit && entryOption.startsWith("Empty|Deposit-1") && ArrayUtils.contains(pouches, widget.getItemId())) || 
+					((hideDeposit && entryOption.startsWith("Empty") && ArrayUtils.contains(pouches, widget.getItemId())) || 
 					(bankFill && entryOption.startsWith("Fill") && ArrayUtils.contains(pouches, widget.getItemId())) ||
 					(swapStam && entryOption.matches("Drink|Withdraw-1") && widget.getItemId() == ItemID.STAMINA_POTION1) ||
 					(swapNeck && entryOption.matches("Wear|Withdraw-1") && widget.getItemId() == ItemID.BINDING_NECKLACE))) {

--- a/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
+++ b/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
@@ -92,6 +92,7 @@ public class EasyEmptyPlugin extends Plugin
 	protected void startUp()
 	{
 		bankFill = config.bankFill();
+		hideDeposit = config.hideDeposit();
 		swapStam = config.swapStam();
 		swapNeck = config.swapNeck();
 		emptyPouches = config.emptyPouches();
@@ -119,16 +120,18 @@ public class EasyEmptyPlugin extends Plugin
 				MenuAction entryType = menuEntries[i].getType();
 				String entryOption = menuEntries[i].getOption();
 
+				
 				if (widget != null && (entryType == MenuAction.CC_OP_LOW_PRIORITY || entryType == MenuAction.CC_OP) &&
-					((bankFill && entryOption.startsWith("Fill") && ArrayUtils.contains(pouches, widget.getItemId())) ||
+					((hideDeposit && entryOption.startsWith("Empty|Deposit-1") && ArrayUtils.contains(pouches, widget.getItemId())) || 
+					(bankFill && entryOption.startsWith("Fill") && ArrayUtils.contains(pouches, widget.getItemId())) ||
 					(swapStam && entryOption.matches("Drink|Withdraw-1") && widget.getItemId() == ItemID.STAMINA_POTION1) ||
 					(swapNeck && entryOption.matches("Wear|Withdraw-1") && widget.getItemId() == ItemID.BINDING_NECKLACE))) {
 					MenuEntry entry = menuEntries[i];
-
+				
 					entry.setType(MenuAction.CC_OP);
 					menuEntries[i] = menuEntries[menuEntries.length - 1];
 					menuEntries[menuEntries.length - 1] = entry;
-
+				
 					client.setMenuEntries(menuEntries);
 					break;
 				}
@@ -184,11 +187,13 @@ public class EasyEmptyPlugin extends Plugin
 			switch (event.getKey()) {
 				case "bankFill":	bankFill = config.bankFill();
 									break;
+				case "hideDeposit":	hideDeposit = config.hideDeposit();
+									break;
 				case "swapNeck":	swapNeck = config.swapNeck();
 									break;
 				case "swapStam":	swapStam = config.swapStam();
 									break;
-				case "emptyPouches":emptyPouches = config.emptyPouches();
+				case "emptyPouches":	emptyPouches = config.emptyPouches();
 									break;
 			}
 		}


### PR DESCRIPTION
I believe the changes I made should seamlessly hide the Deposit option when pouches are full in the bank interface, replacing it with empty instead of deposit.

Please review and let me know if I made a mistake, as I was having some trouble understanding the logic behind the menu entry reordering.