### PR TITLE
Improve Essence Pouch Behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Runecrafting Utilities - v1.3.1
+# Runecrafting Utilities - v1.4.0
 Provides various menu swaps to improve runecrafting
 
 ## Config
-* Empty pouches near altars
+* Left-click empty pouches near altars, regardless of essence in inventory
 * Fill pouches within bank menu
 * Wear Binding Necklace from bank menu
 * Drink Stamina Potion(1) from bank menu
+
+## Experimental
+* Left-click fill pouches when *not* near altars, regardless of essence in inventory
+* Configure pouch shift-click to be consistent regardless of essence in inventory

--- a/build.gradle
+++ b/build.gradle
@@ -6,17 +6,21 @@ repositories {
 	mavenLocal()
 	maven {
 		url = 'https://repo.runelite.net'
+		content {
+			includeGroupByRegex("net\\.runelite.*")
+		}
 	}
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.24.3'
+def runeLiteVersion = 'latest.release'
+def pluginMainClass = 'com.easyEmpty.EasyEmptyPluginTest'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.20'
-	annotationProcessor 'org.projectlombok:lombok:1.18.20'
+	compileOnly 'org.projectlombok:lombok:1.18.30'
+	annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
 	testImplementation 'junit:junit:4.12'
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -24,9 +28,18 @@ dependencies {
 }
 
 group = 'com.easyEmpty'
-version = '1.3.1'
+version = '1.4.0'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+	options.release.set(11)
+}
+
+tasks.register('run', JavaExec) {
+	classpath = sourceSets.test.runtimeClasspath
+	mainClass = pluginMainClass
+
+	jvmArgs "-ea"
+	args "--developer-mode", "--debug"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -43,3 +43,29 @@ tasks.register('run', JavaExec) {
 	jvmArgs "-ea"
 	args "--developer-mode", "--debug"
 }
+
+tasks.register('shadowJar', Jar) {
+	dependsOn configurations.testRuntimeClasspath
+	manifest {
+		attributes('Main-Class': pluginMainClass, 'Multi-Release': true)
+	}
+
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+	from sourceSets.main.output
+	from sourceSets.test.output
+	from {
+		configurations.testRuntimeClasspath.collect { file ->
+			file.isDirectory() ? file : zipTree(file)
+		}
+	}
+
+	exclude 'META-INF/INDEX.LIST'
+	exclude 'META-INF/*.SF'
+	exclude 'META-INF/*.DSA'
+	exclude 'META-INF/*.RSA'
+	exclude '**/module-info.class'
+
+	group = BasePlugin.BUILD_GROUP
+	archiveClassifier.set('shadow')
+	archiveFileName.set("${rootProject.name}-${project.version}-all.jar")
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'runecrafting-utilities - v1.3.1'
+rootProject.name = 'runecrafting-utilities - v1.4.0'

--- a/src/main/java/com/easyEmpty/EasyEmptyConfig.java
+++ b/src/main/java/com/easyEmpty/EasyEmptyConfig.java
@@ -27,31 +27,69 @@ package com.easyEmpty;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+
 
 @ConfigGroup("easyempty")
 public interface EasyEmptyConfig extends Config
 {
-    @ConfigItem(keyName = "emptyPouches", name = "Empty pouches near altar", description = "Left-click empty pouches near altar", position = 1)
+    enum ShiftOption {
+        UNMODIFIED,
+        FILL,
+        EMPTY,
+        DYNAMIC
+    }
+
+    @ConfigItem(keyName = "emptyPouches", name = "Empty pouches near altar",
+            description = "Left-click always empties pouches near altar, regardless of essence in inventory", position = 1)
     default boolean emptyPouches()
     {
         return true;
     }
 
-    @ConfigItem(keyName = "bankFill", name = "Fill pouches from bank", description = "Left-click fill pouches from bank menu", position = 2)
+    @ConfigItem(keyName = "bankFill", name = "Fill pouches from bank",
+            description = "Left-click fills pouches from bank menu", position = 2)
     default boolean bankFill()
     {
         return true;
     }
 
-    @ConfigItem(keyName = "swapStam", name = "Stamina Potion(1) swaps", description = "Left-click drink/withdraw-1 from bank menu", position = 3)
+    @ConfigItem(keyName = "swapStam", name = "Stamina Potion(1) swaps",
+            description = "Left-click drink/withdraw-1 from bank menu", position = 3)
     default boolean swapStam()
     {
         return true;
     }
 
-    @ConfigItem(keyName = "swapNeck", name = "Binding Necklace swaps", description = "Left-click wear/withdraw-1 from bank menu", position = 4)
+    @ConfigItem(keyName = "swapNeck", name = "Binding Necklace swaps",
+            description = "Left-click wear/withdraw-1 from bank menu", position = 4)
     default boolean swapNeck()
     {
         return true;
     }
+
+    @ConfigSection(
+            name = "Experimental",
+            description = "Advanced options for modifying essence pouch behavior",
+            position = 5
+    )
+    String experimental = "experimental";
+
+    @ConfigItem(keyName = "emptyPouchesShift", name = "Altar shift-click",
+            description = "Configure shift-click near an altar. Requires left-click setting enabled. Dynamic flips Fill/Empty. Recommended: Fill or Dynamic",
+            section = experimental, position = 1
+    )
+    default ShiftOption emptyPouchesShift() { return ShiftOption.UNMODIFIED; }
+    @ConfigItem(keyName = "fillPouches",
+            name = "Fill pouches away from altar",
+            description = "Left-click always fills pouches when not near altar, regardless of essence in inventory",
+            section = experimental, position = 2
+    )
+    default boolean fillPouches() { return true; }
+
+    @ConfigItem(keyName = "fillPouchesShift", name = "Non-altar shift-click",
+            description = "Configure shift-click when not near an altar. Requires left-click setting enabled. Dynamic flips Fill/Empty. Recommended: Empty or Dynamic",
+            section = experimental, position = 3
+    )
+    default ShiftOption fillPouchesShift() { return ShiftOption.UNMODIFIED; }
 }

--- a/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
+++ b/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
@@ -201,12 +201,10 @@ public class EasyEmptyPlugin extends Plugin
 	{
 		if (atAltar()) {
 			if (emptyPouches) {
-				log.debug("updatePouches -> emptyPouches");
 				updatePouch("Empty", emptyPouchesShift);
 			}
 		} else {
 			if(fillPouches) {
-				log.debug("updatePouches -> fillPouches");
 				updatePouch("Fill", fillPouchesShift);
 			}
 		}
@@ -279,7 +277,6 @@ public class EasyEmptyPlugin extends Plugin
 
 		MenuEntry entry1 = menuEntries[originalIdx];
 		MenuEntry entry2 = menuEntries[topIdx];
-		log.debug("Swapping " + entry1.getOption() + " and " + entry2.getOption() );
 
 		menuEntries[originalIdx] = entry2;
 		menuEntries[topIdx] = entry1;

--- a/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
+++ b/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
@@ -186,7 +186,9 @@ public class EasyEmptyPlugin extends Plugin
 
 	protected boolean atAltar()
 	{
-		WorldPoint playerLoc = client.getLocalPlayer().getWorldLocation();
+		Player player = client.getLocalPlayer();
+		if (player == null) return false;
+		WorldPoint playerLoc = player.getWorldLocation();
 
 		for (int altarRegion : altars) {
 			if (altarRegion == playerLoc.getRegionID()) {

--- a/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
+++ b/src/main/java/com/easyEmpty/EasyEmptyPlugin.java
@@ -25,12 +25,12 @@
 package com.easyEmpty;
 
 import com.google.inject.Provides;
-import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ClientTick;
+import net.runelite.api.events.PostMenuSort;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
@@ -40,6 +40,8 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.util.Text;
 import org.apache.commons.lang3.ArrayUtils;
+
+import javax.inject.Inject;
 
 @Slf4j
 @PluginDescriptor(
@@ -80,7 +82,8 @@ public class EasyEmptyPlugin extends Plugin
 
 	private static final WorldArea zmi = new WorldArea(new WorldPoint(3050, 5573, 0), 20, 20);
 
-	boolean bankFill, swapStam, swapNeck, emptyPouches;
+	boolean bankFill, swapStam, swapNeck, emptyPouches, fillPouches;
+	EasyEmptyConfig.ShiftOption emptyPouchesShift, fillPouchesShift;
 
 	@Inject
 	private Client client;
@@ -95,6 +98,9 @@ public class EasyEmptyPlugin extends Plugin
 		swapStam = config.swapStam();
 		swapNeck = config.swapNeck();
 		emptyPouches = config.emptyPouches();
+		emptyPouchesShift = config.emptyPouchesShift();
+		fillPouches = config.fillPouches();
+		fillPouchesShift = config.fillPouchesShift();
 		log.info("Easy Empty  started!");
 	}
 
@@ -103,95 +109,184 @@ public class EasyEmptyPlugin extends Plugin
 	{
 		log.info("Easy Empty  stopped!");
 	}
-
-	@Subscribe
-	public void onClientTick(ClientTick event)
-	{
-		if (client.getGameState() != GameState.LOGGED_IN || client.isMenuOpen() || client.isKeyPressed(KeyCode.KC_SHIFT))
-		{
+	// Run after built-in menu swaps
+	@Subscribe(priority=-1)
+	public void onClientTick(ClientTick event) {
+		if (client.getGameState() != GameState.LOGGED_IN) {
 			return;
 		}
+		updateBank();
+		// We call this during game ticks also to avoid flickering from menu entry swapper
+		// Specifically:
+		// 1) At an altar
+		// 2) Mouse hovering over a pouch
+		// 3) Essence in inventory
+		// 4) Shift-click configured for Fill or Empty
+		// Pressing shift causes a staggered update
+		updatePouch();
+	}
 
-		if (client.getWidget(WidgetInfo.BANK_CONTAINER) != null) {
-			MenuEntry[] menuEntries = client.getMenuEntries();
-			for (int i = menuEntries.length - 1; i >= 0; i--) {
-				Widget widget = menuEntries[i].getWidget();
-				MenuAction entryType = menuEntries[i].getType();
-				String entryOption = menuEntries[i].getOption();
-
-				if (widget != null && (entryType == MenuAction.CC_OP_LOW_PRIORITY || entryType == MenuAction.CC_OP) &&
-					((bankFill && entryOption.startsWith("Fill") && ArrayUtils.contains(pouches, widget.getItemId())) ||
-					(swapStam && entryOption.matches("Drink|Withdraw-1") && widget.getItemId() == ItemID.STAMINA_POTION1) ||
-					(swapNeck && entryOption.matches("Wear|Withdraw-1") && widget.getItemId() == ItemID.BINDING_NECKLACE))) {
-					MenuEntry entry = menuEntries[i];
-
-					entry.setType(MenuAction.CC_OP);
-					menuEntries[i] = menuEntries[menuEntries.length - 1];
-					menuEntries[menuEntries.length - 1] = entry;
-
-					client.setMenuEntries(menuEntries);
-					break;
-				}
-			}
-		}
-
-		boolean atAltar = false;
-		WorldPoint playerLoc = client.getLocalPlayer().getWorldLocation();
-
-		if (zmi.contains2D(playerLoc)) {
-			atAltar = true;
-		}
-		else {
-			for (int altarRegion : altars) {
-				if (altarRegion == playerLoc.getRegionID()) {
-					atAltar = true;
-					break;
-				}
-			}
-		}
-
-		if (atAltar) {
-			MenuEntry[] menuEntries = client.getMenuEntries();
-			if (emptyPouches && ArrayUtils.contains(pouches, menuEntries[menuEntries.length -1].getItemId())) {
-				int emptyIdx = -1;
-				int topIdx = menuEntries.length - 1;
-				for (int i = 0; i < topIdx; i++) {
-
-					if (Text.removeTags(menuEntries[i].getOption()).equals("Empty")) {
-						emptyIdx = i;
-						break;
-					}
-				}
-				if (emptyIdx == -1) {
-					return;
-				}
-
-				MenuEntry entry1 = menuEntries[emptyIdx];
-				MenuEntry entry2 = menuEntries[topIdx];
-
-				menuEntries[emptyIdx] = entry2;
-				menuEntries[topIdx] = entry1;
-
-				client.setMenuEntries(menuEntries);
-			}
-		}
+	// Run after built-in menu swaps, so we can detect shift-click swaps
+	@Subscribe(priority=-1)
+	public void onPostMenuSort(PostMenuSort event)
+	{
+		updatePouch();
 	}
 
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
+
 		if (event.getGroup().equals("easyempty")) {
 			switch (event.getKey()) {
-				case "bankFill":	bankFill = config.bankFill();
-									break;
-				case "swapNeck":	swapNeck = config.swapNeck();
-									break;
-				case "swapStam":	swapStam = config.swapStam();
-									break;
-				case "emptyPouches":emptyPouches = config.emptyPouches();
-									break;
+				case "bankFill":			bankFill = config.bankFill();
+					break;
+				case "swapNeck":			swapNeck = config.swapNeck();
+					break;
+				case "swapStam":			swapStam = config.swapStam();
+					break;
+				case "emptyPouches":		emptyPouches = config.emptyPouches();
+					break;
+				case "emptyPouchesShift": 	emptyPouchesShift = config.emptyPouchesShift();
+					break;
+				case "fillPouches": 		fillPouches = config.fillPouches();
+					break;
+				case "fillPouchesShift": 	fillPouchesShift = config.fillPouchesShift();
+					break;
 			}
 		}
+	}
+
+	protected void updateBank() {
+		if (client.isMenuOpen() || client.isKeyPressed(KeyCode.KC_SHIFT)
+				|| client.getWidget(WidgetInfo.BANK_CONTAINER) == null) {
+			return;
+		}
+		MenuEntry[] menuEntries = client.getMenuEntries();
+		for (int i = menuEntries.length - 1; i >= 0; i--) {
+			Widget widget = menuEntries[i].getWidget();
+			MenuAction entryType = menuEntries[i].getType();
+			String entryOption = menuEntries[i].getOption();
+
+			if (widget != null && (entryType == MenuAction.CC_OP_LOW_PRIORITY || entryType == MenuAction.CC_OP) &&
+					((bankFill && entryOption.startsWith("Fill") && ArrayUtils.contains(pouches, widget.getItemId())) ||
+							(swapStam && entryOption.matches("Drink|Withdraw-1") && widget.getItemId() == ItemID.STAMINA_POTION1) ||
+							(swapNeck && entryOption.matches("Wear|Withdraw-1") && widget.getItemId() == ItemID.BINDING_NECKLACE))) {
+				MenuEntry entry = menuEntries[i];
+
+				entry.setType(MenuAction.CC_OP);
+				menuEntries[i] = menuEntries[menuEntries.length - 1];
+				menuEntries[menuEntries.length - 1] = entry;
+
+				client.setMenuEntries(menuEntries);
+				break;
+			}
+		}
+	}
+
+	protected boolean atAltar()
+	{
+		WorldPoint playerLoc = client.getLocalPlayer().getWorldLocation();
+
+		for (int altarRegion : altars) {
+			if (altarRegion == playerLoc.getRegionID()) {
+				return true;
+			}
+		}
+
+		return zmi.contains2D(playerLoc);
+	}
+
+	protected void updatePouch()
+	{
+		if (atAltar()) {
+			if (emptyPouches) {
+				log.debug("updatePouches -> emptyPouches");
+				updatePouch("Empty", emptyPouchesShift);
+			}
+		} else {
+			if(fillPouches) {
+				log.debug("updatePouches -> fillPouches");
+				updatePouch("Fill", fillPouchesShift);
+			}
+		}
+	}
+
+	protected String flipFillEmpty(String currentLeftClick)
+	{
+		if (currentLeftClick.equals("Empty")) return "Fill";
+		if (currentLeftClick.equals("Fill")) return "Empty";
+		// Leave other values unmodified
+		return currentLeftClick;
+	}
+
+	@SuppressWarnings("ReassignedVariable")
+    protected void updatePouch(String desiredLeftClick, EasyEmptyConfig.ShiftOption shiftOption)
+	{
+		if (client.isMenuOpen()) {
+			return;
+		}
+
+		boolean doInvert = false;
+		if (client.isKeyPressed(KeyCode.KC_SHIFT)) {
+			if (shiftOption == EasyEmptyConfig.ShiftOption.UNMODIFIED) {
+				return;
+			}
+			if (shiftOption == EasyEmptyConfig.ShiftOption.FILL) {
+				desiredLeftClick = "Fill";
+			}
+			if (shiftOption == EasyEmptyConfig.ShiftOption.EMPTY) {
+				desiredLeftClick = "Empty";
+			}
+			if (shiftOption == EasyEmptyConfig.ShiftOption.DYNAMIC) {
+				// If the current option is Fill or Empty, then we flip it.
+				// Otherwise, keep it the same
+				doInvert = true;
+			}
+		}
+
+		MenuEntry[] menuEntries = client.getMenuEntries();
+		int topIdx = menuEntries.length - 1;
+		if (!ArrayUtils.contains(pouches, menuEntries[topIdx].getItemId())) {
+			return;
+		}
+
+		if (doInvert) {
+			String currentLeftClick = Text.removeTags(menuEntries[topIdx].getOption());
+
+			desiredLeftClick = flipFillEmpty(currentLeftClick);
+			if (desiredLeftClick.equals(currentLeftClick)) return;
+		}
+
+		setLeftClick(menuEntries, desiredLeftClick);
+	}
+
+	// Takes in menuEntries to avoid multiple get calls
+	protected void setLeftClick(MenuEntry[] menuEntries, String desiredLeftClick)
+	{
+		final int topIdx = menuEntries.length - 1;
+		int originalIdx = -1;
+		for (int i = 0; i < topIdx; i++) {
+			if (Text.removeTags(menuEntries[i].getOption()).equals(desiredLeftClick)) {
+				originalIdx = i;
+				break;
+			}
+		}
+		if (originalIdx == -1) {
+			// Option is already on top
+			return;
+		}
+
+		MenuEntry entry1 = menuEntries[originalIdx];
+		MenuEntry entry2 = menuEntries[topIdx];
+		log.debug("Swapping " + entry1.getOption() + " and " + entry2.getOption() );
+
+		menuEntries[originalIdx] = entry2;
+		menuEntries[topIdx] = entry1;
+		// The swap is done correctly, but the top entry isn't left-clickable
+		menuEntries[originalIdx].setType(MenuAction.CC_OP);
+		menuEntries[topIdx].setType(MenuAction.CC_OP);
+		client.setMenuEntries(menuEntries);
 	}
 
 	@Provides


### PR DESCRIPTION
Hi! Hoping this is still being maintained. I took a few hours to rewrite a good portion of this. If not being maintained, I may reach out to RuneLite folks at some point to get my fork made into its own plugin, although I'd love to not have to make that PR! Everything does appear pretty stable as far as I can tell, and certainly quite functional (the important part!)

Improved Essence Pouch behavior in a few ways, to allow better control over the changes introduced in the January 8, 2025 update:

1) Added option to set left-click to "Fill" when not near an altar. This is handy for GotR, to avoid emptying your pouch unless you're at an altar. This was added under a new "Experimental" section.

2) With "Empty pouches near altar", when essence was in inventory at an altar, the left-click option would change to "Check". It now remains "Empty". This addresses #19 .

3) Customizing shift-click doesn't work well with the plugin, so added new shift-click options (under Experimental) to either keep the original behavior. By default, the behavior remains unchanged, but it can be modified to either always be fill/empty, or swap fill/empty dynamically, if the right-click option is set.

No changes to other options (stams/binding necks/bank essence).

Finally, to get this working on my end, I updated part of build.gradle, notably to move `runeLiteVersion` to `latest.release`. I'm calling this version 1.4.0, as it's a relatively major update.